### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub - part of the GitHub Certifications program for college applications",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the missing "GitHub Skills" activity to the extracurricular activities system.

## Changes

- Added "GitHub Skills" activity to the activities dictionary in `src/app.py`
- Configured with appropriate schedule (Mondays & Thursdays, 3:30-4:30 PM)
- Set max participants to 25
- Includes description linking to GitHub Certifications program

## Addresses Issue

Fixes #6 - 🚨 Missing Activity: GitHub Skills

This was a time-sensitive request as mentioned in the issue, with registrations closing by end of week. The activity is now available for student registration just like other activities.

## Testing

The activity will now appear in:
- The activities list on the main page
- The dropdown menu for student sign-ups
- API responses from `/activities` endpoint

Students can now sign up for the GitHub Skills activity that was announced by the principal during the school assembly.